### PR TITLE
Fix `types.ts`

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -1,4 +1,4 @@
-const enum Types {
+export const enum Types {
   INFO = "info",
   WARN = "warn",
   ERROR = "error",


### PR DESCRIPTION
I'm trying to use the latest versions of this library (`1.1.1` and `1.1.2`), but I'm getting some weird errors:
```txt
error: Uncaught TypeError: Cannot read properties of undefined (reading 'INFO')
  private [Types.INFO]: string = "";
                 ^
    at https://deno.land/x/logger@v1.1.2/writer.ts:11:18
```
Then I checked the repo and found that `types.ts` has:
```ts
const enum Types {
  INFO = "info",
  WARN = "warn",
  ERROR = "error",
}

export default Types;
```
However, `Types` is a `const` enum, something that isn't visible to other modules by default. Adding an `export` or removing that `const` would fix this.