### PR TITLE
Add an option to force a filename to the final log file

### DIFF
--- a/interface.ts
+++ b/interface.ts
@@ -13,6 +13,7 @@ export interface WriterWrite {
 
 export interface fileLoggerOptions extends WriterConstructor {
   rotate?: boolean;
+  filename?: string;
 }
 
 export interface LoggerWriteOptions {

--- a/logger.ts
+++ b/logger.ts
@@ -21,6 +21,7 @@ export default class Logger {
   private writer?: Writer;
   private rotate = false;
   private dir?: string;
+  private filename?: string;
 
   #debug = this.debug;
   #info = this.info;
@@ -123,7 +124,8 @@ export default class Logger {
 
   private write({ dir, type, args }: LoggerWriteOptions): Promise<void> {
     const date = this.getDate();
-    const filename = this.rotate === true ? `${date}_${type}` : type;
+    const filename = this.filename ||
+      (this.rotate === true ? `${date}_${type}` : type);
     const path = `${dir}/${filename}.log`;
     const msg = this.format(...args);
     return this.writer!.write({ path, msg, type });
@@ -151,6 +153,7 @@ export default class Logger {
     const { rotate, maxBytes, maxBackupCount } = options;
     if (rotate === true) this.rotate = true;
     this.dir = dir;
+    this.filename = options?.filename;
     this.writer = new Writer({
       maxBytes,
       maxBackupCount,


### PR DESCRIPTION
This will enable users to specify the desired file name for the processed data. 
As the same file may be used multiple times, this allows for controlled file management on my end.

